### PR TITLE
Fuzz-testing with stats on a sequence of passes 

### DIFF
--- a/include/trieste/driver.h
+++ b/include/trieste/driver.h
@@ -109,6 +109,11 @@ namespace trieste
       bool test_failfast = false;
       test->add_flag("-f,--failfast", test_failfast, "Stop on first failure");
 
+      // Test passes in sequence
+      bool test_sequence = false; 
+      test->add_flag("--sequence", 
+                     test_sequence, 
+                     "Run all passes on generated tree from start pass");
       try
       {
         app.parse(argc, argv);
@@ -185,14 +190,15 @@ namespace trieste
           test_end_pass = test_start_pass;
         }
 
-        return Fuzzer(reader)
+        Fuzzer fuzzer = Fuzzer(reader)
           .max_depth(test_max_depth)
           .failfast(test_failfast)
           .seed_count(test_seed_count)
           .start_index(reader.pass_index(test_start_pass))
           .end_index(reader.pass_index(test_end_pass))
-          .start_seed(test_seed)
-          .test();
+          .start_seed(test_seed); 
+
+        return test_sequence ? fuzzer.test_sequence() : fuzzer.test();
       }
 
       return ret;

--- a/include/trieste/fuzzer.h
+++ b/include/trieste/fuzzer.h
@@ -200,5 +200,161 @@ namespace trieste
 
       return ret;
     }
+
+
+    int test_sequence()
+      { 
+        WFContext context;
+        int ret = 0;
+        size_t passed_count = 0;
+        size_t failed_count = 0;
+        size_t trivial_count = 0;
+        // Passes that resulted in error and their count of different error msgs
+        std::map<std::string, std::map<std::string,size_t>> error_passes;
+
+        // Starting pass 
+        auto& init_pass = passes_.at(start_index_ - 1);
+        auto& init_wf = init_pass->wf();
+        auto& gen_wf = start_index_ > 1 
+              ? passes_.at(start_index_ - 2)->wf() 
+              : *input_wf_;
+
+        if (!gen_wf || !init_wf){
+            logging::Error() << "cannot generate tree without a specification!"
+                             << std::endl; 
+          return 1; 
+        }
+
+        logging::Info() << "Fuzzing sequence from " 
+                  << passes_.at(start_index_ - 1)->name() 
+                  << " to "
+                  << passes_.at(end_index_ - 1)->name() 
+                  << std::endl
+                  << "============" << std::endl;
+
+        for (size_t seed = start_seed_; 
+             seed < start_seed_ + seed_count_;
+             seed++)
+        {               
+          bool changed = false; //True if at least one passed run changed the tree
+          bool seq_ok = true;   //False if no WF-errors occured 
+          bool errored = false; //True if Error nodes were added to the tree 
+
+          // Generate initial ast  
+          auto ast = gen_wf.gen(generators_, seed, max_depth_);
+
+          for (auto i = start_index_; i < end_index_; i++)
+          { 
+            auto& pass = passes_.at(i - 1);
+            auto& wf = pass->wf();
+            auto& prev = i > 1 
+                ? passes_.at(i - 2)->wf() 
+                : *input_wf_;
+
+              if (!prev || !wf)
+              {
+                logging::Info() << "Skipping pass: " << pass->name() << std::endl;
+                continue;
+              }
+              context.push_back(prev);
+              context.push_back(wf);
+              
+              auto ast_copy = ast->clone(); //Save clone before running pass 
+            
+              auto [new_ast, count, changes] = pass->run(ast);
+              ast = new_ast;
+
+              if (changes > 0) changed = true;
+
+              logging::Trace() << "============" << std::endl
+                           << "applying pass " << pass->name() 
+                           << std::endl
+                           << ast_copy 
+                           << "------------" << std::endl
+                           << new_ast << "------------" << std::endl;
+
+              // TODO: Why are we building the symbol tables here?
+              auto ok = wf.build_st(new_ast);
+              if (ok)
+              {
+                Nodes errors;
+                new_ast->get_errors(errors);
+                if (!errors.empty()) {
+                  Node error = errors.front();
+                  errored = true; 
+                  for (auto& c : *error) {
+                    if(c->type() == ErrorMsg) {
+                      auto err_msg = std::string(c->location().view());
+                      error_passes[pass->name()][err_msg]++; 
+                      break;
+                    }
+                  }
+                  break; // No need to run subsequent passes if Error is found
+                }
+              }
+              ok = wf.check(new_ast) && ok;
+
+              if (!ok)
+              {
+                logging::Error err;
+                if (!logging::Trace::active())
+                {
+                  // We haven't printed what failed with Trace earlier, so do it
+                  // now.
+                  err << "============" << std::endl
+                      << "------------" << std::endl
+                      << ast_copy << "------------" << std::endl
+                      << "resulted in ill-formed tree: " << std::endl
+                      << new_ast << "------------" << std::endl;
+                }
+                seq_ok = false;
+                ret = 1;
+
+                if (failfast_)
+                  return ret;
+              }
+
+              context.pop_front();
+              context.pop_front();
+
+          } //End sequence loop 
+
+          if (seq_ok && !errored) passed_count++;
+          if (!seq_ok) failed_count++;
+          // TODO: Need different criteria for trivial 
+          // e.g. (Top File) --> (Top Calculation) is a change but is not very 
+          // interesting 
+          if (seq_ok && !changed) trivial_count++;
+          
+        } //End tree generating loop 
+
+        // Log stats 
+        logging::Info info;
+        if (failed_count > 0) info << "  not WF " << failed_count << " times." << std::endl;
+
+        if (!error_passes.empty())
+        {
+          for (auto [pass_name, err_msgs] : error_passes) 
+          {
+            const std::size_t sum = std::accumulate(
+              std::begin(err_msgs),
+              std::end(err_msgs),
+              static_cast<std::size_t>(0),
+              [](const std::size_t acc, const std::pair<const std::string, std::size_t>& c)
+              { return acc + c.second; });
+            info << "pass " << pass_name << " resulted in error : " << sum << " times." << std::endl; 
+            for (auto [msg,count] : err_msgs)
+            {
+              info << "    " << msg << ": " << count << std::endl;
+            }
+          }
+        }
+        if ((!error_passes.empty() && passed_count > 0) || trivial_count > 0)
+        {
+          info << "passed sequence: " << passed_count << " times." << std::endl;
+          if (trivial_count > 0) info << "trivial: " << trivial_count << std::endl;
+        }
+        return ret;
+      }
   };
 }


### PR DESCRIPTION
Added `--sequence` as a new command line option in `driver.h` for running all passes in the range `[start , end]` on trees generated for the initial pass `start`. If the `--sequence` flag is set, we call `test_sequence()` instead of `test()` on the fuzzer. Similar stats are logged in both cases. 

In `test_sequence`, if error-nodes are found, no more passes are applied to the tree. Instead, a new tree is generated and the sequence is restarted from the `start` pass.  




